### PR TITLE
Harden output escaping and require auth on the sizes REST route

### DIFF
--- a/includes/class-dashboard-directory-size-dashboard-widget.php
+++ b/includes/class-dashboard-directory-size-dashboard-widget.php
@@ -122,7 +122,7 @@ if ( ! class_exists( 'Dashboard_Directory_Size_Dashboard_Widget' ) ) {
 				} else if ( ! empty( $directory['database'] ) ) {
 					$cell_size_class[] = 'cell-database';
 					$cell_size_class[] = 'cell-has-size';
-					$data_size = ' data-size="' . esc_attr( $directory['size'] ) . '"';
+					$data_size = $directory['size'];
 				} else if ( -2 === $size ) {
 					// a size of -2 means we need to load it via the REST API
 					$cell_size_class[] = 'cell-size-data';
@@ -139,9 +139,10 @@ if ( ! class_exists( 'Dashboard_Directory_Size_Dashboard_Widget' ) ) {
 						<td class="<?php echo esc_attr( implode( ' ', $cell_size_class ) ); ?>" data-path="<?php echo esc_attr( $directory['path'] ); ?>">
 
 							<span class="spinner <?php echo ( -2 === $size ? 'is-active' : '' ); ?> hidden"></span>
-							<span class="size" <?php
-								// Holds a full attribute; its value is passed through esc_attr() above.
-								echo $data_size; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+							<span class="size"<?php
+								if ( '' !== $data_size ) {
+									echo ' data-size="' . esc_attr( $data_size ) . '"';
+								}
 							?>>
 							<?php
 

--- a/includes/class-dashboard-directory-size-dashboard-widget.php
+++ b/includes/class-dashboard-directory-size-dashboard-widget.php
@@ -139,7 +139,10 @@ if ( ! class_exists( 'Dashboard_Directory_Size_Dashboard_Widget' ) ) {
 						<td class="<?php echo esc_attr( implode( ' ', $cell_size_class ) ); ?>" data-path="<?php echo esc_attr( $directory['path'] ); ?>">
 
 							<span class="spinner <?php echo ( -2 === $size ? 'is-active' : '' ); ?> hidden"></span>
-							<span class="size" <?php echo $data_size; ?>>
+							<span class="size" <?php
+								// Holds a full attribute; its value is passed through esc_attr() above.
+								echo $data_size; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+							?>>
 							<?php
 
 								switch ( $size ) {

--- a/includes/class-dashboard-directory-size-rest-api.php
+++ b/includes/class-dashboard-directory-size-rest-api.php
@@ -14,8 +14,9 @@ if ( ! class_exists( 'Dashboard_Directory_Size_REST_API' ) ) {
 			if ( $enabled ) {
 				register_rest_route( self::api_namespace(), '/v1/sizes',
 					array(
-						'methods'    => WP_REST_Server::READABLE,
-						'callback'   => 'Dashboard_Directory_Size_REST_API::get_sizes',
+						'methods'             => WP_REST_Server::READABLE,
+						'callback'            => 'Dashboard_Directory_Size_REST_API::get_sizes',
+						'permission_callback' => 'is_user_logged_in',
 						)
 					);
 			}

--- a/includes/class-dashboard-directory-size-settings.php
+++ b/includes/class-dashboard-directory-size-settings.php
@@ -272,7 +272,7 @@ if ( ! class_exists( 'Dashboard_Directory_Size_Settings' ) ) {
 			$default     = $args['default'];
 
 			$option      = get_option( $key );
-			$value       = isset( $option[ $name ] ) ? esc_attr( $option[ $name ] ) : $default;
+			$value       = isset( $option[ $name ] ) ? $option[ $name ] : $default;
 
 			$min_max_step = '';
 			if ( $type === 'number' ) {
@@ -291,7 +291,10 @@ if ( ! class_exists( 'Dashboard_Directory_Size_Settings' ) ) {
 					value="<?php echo esc_attr( $value ); ?>"
 					size="<?php echo esc_attr( $size ); ?>"
 					maxlength="<?php echo esc_attr( $maxlength ); ?>"
-					<?php echo $min_max_step; ?> />
+					<?php
+					// Built by sprintf() from integers only, so it is safe markup.
+					echo $min_max_step; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					?> />
 				</div>
 			<?php 
 
@@ -337,7 +340,7 @@ if ( ! class_exists( 'Dashboard_Directory_Size_Settings' ) ) {
 
 					<?php foreach ( $items as $value => $value_dispay ) : ?>
 						<label>
-							<input type="checkbox" name="<?php echo $key ?>[<?php echo $name ?>][]" value="<?php echo $value ?>" <?php checked( in_array( $value, $values) ); ?> />
+							<input type="checkbox" name="<?php echo esc_attr( $key . '[' . $name . '][]' ); ?>" value="<?php echo esc_attr( $value ); ?>" <?php checked( in_array( $value, $values) ); ?> />
 							<?php echo esc_html( $value_dispay ); ?>
 						</label>
 						<br/>
@@ -369,7 +372,7 @@ if ( ! class_exists( 'Dashboard_Directory_Size_Settings' ) ) {
 			$after  = $args['after'];
 
 			$option = get_option( $key );
-			$value  = isset( $option[$name] ) ? esc_attr( $option[$name] ) : '';
+			$value  = isset( $option[$name] ) ? $option[$name] : '';
 
 			?>
 				<div>
@@ -404,8 +407,13 @@ if ( ! class_exists( 'Dashboard_Directory_Size_Settings' ) ) {
 			}
 
 			echo '<div>';
-			echo "<label><input id='{$name}_1' name='{$key}[{$name}]'  type='radio' value='1' " . ( '1' === $value ? " checked=\"checked\"" : "" ) . "/>" . esc_html__( 'Yes' ) . "</label> ";
-			echo "<label><input id='{$name}_0' name='{$key}[{$name}]'  type='radio' value='0' " . ( '0' === $value ? " checked=\"checked\"" : "" ) . "/>" . esc_html__( 'No' ) . "</label> ";
+			$id_yes = esc_attr( $name . '_1' );
+			$id_no  = esc_attr( $name . '_0' );
+			$field  = esc_attr( $key . '[' . $name . ']' );
+
+			// $id_yes, $id_no and $field are escaped above; the rest is literal markup.
+			echo "<label><input id='{$id_yes}' name='{$field}'  type='radio' value='1' " . ( '1' === $value ? " checked=\"checked\"" : "" ) . "/>" . esc_html__( 'Yes' ) . "</label> "; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			echo "<label><input id='{$id_no}' name='{$field}'  type='radio' value='0' " . ( '0' === $value ? " checked=\"checked\"" : "" ) . "/>" . esc_html__( 'No' ) . "</label> "; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			echo '</div>';
 
 			self::output_after( $after );
@@ -458,10 +466,10 @@ if ( ! class_exists( 'Dashboard_Directory_Size_Settings' ) ) {
 
 		static public function plugin_options_tabs() {
 			$current_tab = self::current_tab();
-			echo '<h2>' . __( 'Settings' ) . ' &rsaquo; Dashboard Directory Size</h2><h2 class="nav-tab-wrapper">';
+			echo '<h2>' . esc_html__( 'Settings' ) . ' &rsaquo; Dashboard Directory Size</h2><h2 class="nav-tab-wrapper">';
 			foreach ( self::$plugin_settings_tabs as $tab_key => $tab_caption ) {
 				$active = $current_tab == $tab_key ? 'nav-tab-active' : '';
-				echo '<a class="nav-tab ' . $active . '" href="?page=' . urlencode( self::$settings_page ) . '&tab=' . urlencode( $tab_key ) . '">' . esc_html( $tab_caption ) . '</a>';
+				echo '<a class="nav-tab ' . esc_attr( $active ) . '" href="?page=' . urlencode( self::$settings_page ) . '&tab=' . urlencode( $tab_key ) . '">' . esc_html( $tab_caption ) . '</a>';
 			}
 			echo '</h2>';
 		}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<ruleset name="Dashboard Directory Size">
+
+	<description>Security and correctness rules for the Dashboard Directory Size plugin.</description>
+
+	<!-- Scanned when no file/directory is passed on the command line. -->
+	<file>.</file>
+
+	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<exclude-pattern>*/node_modules/*</exclude-pattern>
+	<exclude-pattern>*/features/*</exclude-pattern>
+	<exclude-pattern>*/tests/*</exclude-pattern>
+	<exclude-pattern>*/languages/*</exclude-pattern>
+	<exclude-pattern>*.js</exclude-pattern>
+	<exclude-pattern>*.css</exclude-pattern>
+
+	<arg name="extensions" value="php"/>
+	<arg name="colors"/>
+	<arg value="sp"/>
+
+	<!-- Warnings are reported but do not fail the build; errors do. -->
+	<config name="ignore_warnings_on_exit" value="1"/>
+
+	<config name="minimum_supported_wp_version" value="5.9"/>
+	<config name="testVersion" value="7.4-"/>
+
+	<!--
+		Deliberately scoped to security and correctness rather than the full
+		WordPress standard. The existing code predates WPCS formatting rules and
+		a repo-wide reformat would bury real findings in whitespace churn.
+	-->
+	<rule ref="WordPress.Security"/>
+	<rule ref="WordPress.DB.PreparedSQL"/>
+	<rule ref="WordPress.DB.DirectDatabaseQuery"/>
+	<rule ref="WordPress.WP.EnqueuedResourceParameters"/>
+	<rule ref="WordPress.PHP.NoSilencedErrors"/>
+	<rule ref="Generic.PHP.Syntax"/>
+
+</ruleset>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,79 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Action callback returns mixed but should not return anything\.$#'
+			identifier: return.void
+			count: 2
+			path: includes/class-dashboard-directory-size-common.php
+
+		-
+			message: '#^Constant DB_NAME not found\.$#'
+			identifier: constant.notFound
+			count: 2
+			path: includes/class-dashboard-directory-size-common.php
+
+		-
+			message: '#^Filter callback return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: includes/class-dashboard-directory-size-common.php
+
+		-
+			message: '#^Method Dashboard_Directory_Size_Common\:\:filter_get_directory_size\(\) with return type void returns int but should not return anything\.$#'
+			identifier: return.void
+			count: 1
+			path: includes/class-dashboard-directory-size-common.php
+
+		-
+			message: '#^Method Dashboard_Directory_Size_Common\:\:get_custom_dir\(\) should return array but returns null\.$#'
+			identifier: return.type
+			count: 1
+			path: includes/class-dashboard-directory-size-common.php
+
+		-
+			message: '#^Variable \$custom_dir_list in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: includes/class-dashboard-directory-size-common.php
+
+		-
+			message: '#^Variable \$parts in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: includes/class-dashboard-directory-size-common.php
+
+		-
+			message: '#^Variable \$upload_dir in empty\(\) always exists and is not falsy\.$#'
+			identifier: empty.variable
+			count: 1
+			path: includes/class-dashboard-directory-size-common.php
+
+		-
+			message: '#^Constant DASHBOARD_DIRECOTRY_SIZE_ROOT not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: includes/class-dashboard-directory-size-settings.php
+
+		-
+			message: '#^Function DashboardDirectorySize\\Sanitizers\\sanitized_post_array\(\) should return string but returns array\.$#'
+			identifier: return.type
+			count: 1
+			path: includes/sanitizers.php
+
+		-
+			message: '#^Static method WP_CLI\:\:line\(\) invoked with 2 parameters, 0\-1 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: includes/wp-cli/class-dashboard-directory-size-command.php
+
+		-
+			message: '#^Static method WP_CLI\:\:success\(\) invoked with 2 parameters, 1 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: includes/wp-cli/class-dashboard-directory-size-command.php
+
+		-
+			message: '#^Constant DASHBOARD_DIRECOTRY_SIZE_ROOT not found\.$#'
+			identifier: constant.notFound
+			count: 1
+			path: includes/wp-cli/setup.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,20 @@
+includes:
+	- vendor/szepeviktor/phpstan-wordpress/extension.neon
+	# Pre-existing findings, so the hook only gates newly written code.
+	# Regenerate with: phpstan analyse --generate-baseline=phpstan-baseline.neon
+	- phpstan-baseline.neon
+
+parameters:
+	level: 3
+
+	paths:
+		- dashboard-directory-size.php
+		- uninstall.php
+		- includes
+		- admin
+
+	bootstrapFiles:
+		- vendor/php-stubs/wp-cli-stubs/wp-cli-stubs.php
+
+	scanFiles:
+		- vendor/php-stubs/wp-cli-stubs/wp-cli-commands-stubs.php


### PR DESCRIPTION
## Summary

Follow-up to an XSS audit of the plugin. **No exploitable XSS was found** — all `$_GET` access is centralized through `includes/sanitizers.php` and never reflected into HTML, the one free-text setting (`custom-directories`) is stripped on save and escaped on output, and `admin/js/dashboard-widget.js` uses `.text()` exclusively for REST data.

Three issues were still worth closing.

### 1. Unescaped output with internally-controlled data

`settings_checkbox_list()` and `settings_yes_no()` interpolated `$key`/`$name`/`$value` straight into `id` and `name` attributes, and `plugin_options_tabs()` echoed a translated string unescaped.

These were safe only because every current caller passes literals. Escaping them removes the trap for a future `add_settings_field()` call that sources those args from stored data, and closes the (narrow) malicious-translation-file vector on `__( 'Settings' )`.

### 2. Double-escaping

`settings_input()` and `settings_textarea()` ran `esc_attr()` at assignment and again at output. A custom directory path containing `&` rendered as `&amp;amp;` and corrupted itself on every re-save. Now escaped once, at output.

### 3. `/v1/sizes` had no `permission_callback`

`register_rest_route()` for `/v1/sizes` registered with no `permission_callback` at all, while the plugin's three other routes all use `is_user_logged_in`. Whenever the **REST API Support** setting was enabled, this exposed absolute server filesystem paths, the database name, and directory sizes to **unauthenticated** requests. Since WP 5.5 it also triggers a `_doing_it_wrong()` notice.

Fixed to match the sibling routes. Worth discussing whether this should be `manage_options` instead — the data is admin-only in nature, and the dashboard widget itself is gated on that capability. I went with the consistent minimal fix.

## Pre-commit hook

The repo's `.git/hooks/pre-commit` could not pass on any commit: it ran `phpcs --standard=phpcs.xml.dist` against a file that was never committed, and `phpstan analyse` with no path and no config (reporting 125 phantom "function not found" errors for lack of WP stubs). This PR adds both configs.

- **`phpcs.xml.dist`** is deliberately scoped to security and correctness sniffs rather than the full `WordPress` standard, which reports 392 mostly-formatting errors on this codebase. A repo-wide reformat would have buried the actual security fixes. Warnings report but don't fail the build.
- **`phpstan.neon.dist`** wires up `szepeviktor/phpstan-wordpress` and the `php-stubs/wordpress-stubs` already present in `vendor/`, at level 3.
- **`phpstan-baseline.neon`** captures the 15 pre-existing findings so the hook gates only newly written code. Regenerate with `phpstan analyse --generate-baseline=phpstan-baseline.neon`.

Four pre-escaped outputs that phpcs cannot trace through a variable are annotated with `phpcs:ignore` plus a note on why they're safe. phpcs errors on the touched files went 9 → 0, with none suppressed that weren't already verified by hand.

## Known follow-ups (not addressed here)

- **`composer.json` is badly out of sync with `composer.lock`.** The lock carries the modern toolchain the hook needs (phpcs 3.13.5, phpstan 2.2.2, wpcs 3.3.0, the stubs) while `composer.json` still declares phpcs `^2.5` / phpunit `^4.8` and no phpstan, and the lock has no `_content-hash`. A fresh `composer install` will not reproduce a working hook. Regenerating the lock is a substantial change with its own risk, so I left it alone.
- **`get_database_size()` runs an uncached `information_schema` query on every widget render.** phpcs flags this (`WordPress.DB.DirectDatabaseQuery.NoCaching`) and the warning is legitimate — the transient caching in `get_directory_size()` covers filesystem paths only, not the database row. Left visible as a warning rather than suppressed.
- `common.php` `get_path_for_common_dir()` has a missing `break` in the `uploads` case — harmless today since each branch returns, but it falls through to `themes` if `wp_upload_dir()` returns empty.

## QA steps

1. Enable **REST API Support** in Settings → Dashboard Directory Size.
2. Log out (or use a private window) and request `/wp-json/dashboard-directory-size/v1/sizes`. Expect `401` with `rest_forbidden`; before this change it returned full server paths and the DB name.
3. Log back in as an admin and request the same endpoint — it should return the size list as before.
4. On the settings page, confirm the Common Directories checkboxes, both Yes/No radio pairs, and the numeric inputs still render, save, and reload correctly.
5. Enter a custom directory whose name contains `&`, e.g. `Cache & Temp | ~/wp-content/`. Save, then reload the settings page — the name should stay `Cache & Temp` rather than degrading to `&amp;amp;`. Confirm it renders correctly in the dashboard widget too.
6. Confirm the dashboard widget still loads sizes over AJAX and the total row sums correctly.
